### PR TITLE
Fix a typo in docs

### DIFF
--- a/docs/examples/lightcurves.rst
+++ b/docs/examples/lightcurves.rst
@@ -20,4 +20,4 @@ Wollaeger
 
 Tim Dietrich and Maximiliano Ujevic
 -----------------------------------
-`here <(https://arxiv.org/pdf/1612.03665.pdf>`_
+`here <https://arxiv.org/pdf/1612.03665.pdf>`_


### PR DESCRIPTION
This should fix the broken link on https://gwemlightcurves.github.io/examples/lightcurves.html. (though I haven't tested it)