### PR TITLE
List afterglowpy as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ https://gwemlightcurves.github.io/
 
 
 ################################
-->in gwemlightcurves/TrPi2018.py there is 
-import grbpy
-->you need to install afterglowpy and change the previous command with 
-import afterglowpy as grbpy
 ->When installing Multinest, make sure to:
 export LD_LIBRARY_PATH=/home/user/MultiNest/lib/:$LD_LIBRARY_PATH
 echo 'export_LD_LIBRARY_PATH=/home/user/MultiNest/lib/:$LD_LIBRARY_PATH' >>/home/user/.bashrc

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ install_requires = [
     'pymultinest',
     'requests',
     'penquins',
+    'afterglowpy'
 ]
 tests_require = [
     'pytest'


### PR DESCRIPTION
Add `afterglowpy` to the list of dependencies since it is needed to `import gwemlightcurves.sampler.model`.

@mcoughlin if you would like to handle this differently, feel free to just close the PR.